### PR TITLE
Cancel animation frame on component unmounting

### DIFF
--- a/src/MorphReplace.js
+++ b/src/MorphReplace.js
@@ -32,6 +32,7 @@ class MorphReplace extends React.Component {
 
 
     componentWillUnmount() {
+        cancelAnimationFrame(this.raf);
         // TODO
         // not sure should we call componentWillUnomunt on childrens
     }


### PR DESCRIPTION
Clear animation frame on component unmounting to prevent errors if the component is unmounted while animating.

I had the case on a page transition, the `this.setState` call in the animation frame handler caused errors. 
